### PR TITLE
Suppress vstack warning by wrapping iterator

### DIFF
--- a/gym-ipp/gym_ipp/envs/ipp_env.py
+++ b/gym-ipp/gym_ipp/envs/ipp_env.py
@@ -18,8 +18,12 @@ from ipp_toolkit.utils.sampling import get_flat_samples
 def get_grid_delta(size, resolution):
     delta = (
         np.vstack(
-            s.flatten()
-            for s in np.meshgrid(np.arange(size[0]), np.arange(size[1]), indexing="ij")
+            [
+                s.flatten()
+                for s in np.meshgrid(
+                    np.arange(size[0]), np.arange(size[1]), indexing="ij"
+                )
+            ]
         )
         .astype(float)
         .T


### PR DESCRIPTION
A simple fix to suppress warning about future depreciation that shows up each time you run or train. 